### PR TITLE
feat: add endpoint to serve OpenAPI JSON documentation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { AppModule } from './app.module';
 import { initializeDataSource } from './database/data-source';
 import { SeedingService } from './database/seeding/seeding.service';
 import { ResponseInterceptor } from './shared/inteceptors/response.interceptor';
+import { Request, Response } from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, { bufferLogs: true });
@@ -42,6 +43,12 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, options);
   SwaggerModule.setup('api/docs', app, document);
+
+  // Endpoint to serve the OpenAPI JSON
+  app.use('api/docs-json', (req: Request, res: Response) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.send(document);
+  });
 
   const port = app.get<ConfigService>(ConfigService).get<number>('server.port');
   await app.listen(port);


### PR DESCRIPTION
- Create a new Express route at 'api/docs-json'
- Expose the Swagger document as a JSON endpoint
- Allow direct access to the OpenAPI specification